### PR TITLE
Added support for special handling of pipe fluids and spouts

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
@@ -1,11 +1,18 @@
 package dev.latvian.mods.kubejs.create;
 
 import com.simibubi.create.AllRecipeTypes;
+import com.simibubi.create.api.behaviour.BlockSpoutingBehaviour;
+import com.simibubi.create.content.contraptions.fluids.OpenEndedPipe;
 import com.simibubi.create.content.contraptions.processing.ProcessingRecipeSerializer;
+import com.simibubi.create.foundation.utility.Pair;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
 import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
 import dev.latvian.mods.kubejs.recipe.RegisterRecipeHandlersEvent;
+import dev.latvian.mods.kubejs.script.ScriptType;
 import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author LatvianModder
@@ -14,6 +21,17 @@ public class KubeJSCreatePlugin extends KubeJSPlugin {
 	@Override
 	public void init() {
 		RegistryObjectBuilderTypes.ITEM.addType("create:sequenced_assembly", SequencedAssemblyItemBuilder.class, SequencedAssemblyItemBuilder::new);
+	}
+
+	@Override
+	public void afterInit() {
+		List<OpenEndedPipe.IEffectHandler> effects = new ArrayList<>();
+		new SpecialFluidHandlerEvent(effects).post(ScriptType.STARTUP, SpecialFluidHandlerEvent.ID);
+		effects.forEach(OpenEndedPipe::registerEffectHandler);
+
+		List<Pair<ResourceLocation, BlockSpoutingBehaviour>> spouts = new ArrayList<>();
+		new SpecialSpoutHandlerEvent(spouts).post(ScriptType.STARTUP, SpecialSpoutHandlerEvent.ID);
+		spouts.forEach(s -> BlockSpoutingBehaviour.addCustomSpoutInteraction(s.getFirst(), s.getSecond()));
 	}
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/create/SpecialFluidHandlerEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/create/SpecialFluidHandlerEvent.java
@@ -1,0 +1,48 @@
+package dev.latvian.mods.kubejs.create;
+
+import com.simibubi.create.content.contraptions.fluids.OpenEndedPipe;
+import com.simibubi.create.foundation.fluid.FluidIngredient;
+import dev.architectury.hooks.fluid.forge.FluidStackHooksForge;
+import dev.latvian.mods.kubejs.event.EventJS;
+import dev.latvian.mods.kubejs.fluid.FluidStackJS;
+import dev.latvian.mods.kubejs.util.MapJS;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+/**
+ * @author Prunoideae
+ */
+public class SpecialFluidHandlerEvent extends EventJS {
+	public static final String ID = "create.pipe.fluid_effect";
+
+	private final List<OpenEndedPipe.IEffectHandler> fluidHandlers;
+
+	public SpecialFluidHandlerEvent(List<OpenEndedPipe.IEffectHandler> fluidHandlers) {
+		this.fluidHandlers = fluidHandlers;
+	}
+
+	public void addFluidHandler(Object fluidStack, BiConsumer<OpenEndedPipe, FluidStackJS> handler) {
+		FluidIngredient fluidIngredient;
+		if (fluidStack instanceof FluidStackJS fluidStackJS) {
+			fluidIngredient = FluidIngredient.fromFluidStack(FluidStackHooksForge.toForge(fluidStackJS.getFluidStack()));
+		} else if (fluidStack instanceof MapJS map && (map.containsKey("fluid") || map.containsKey("fluidTag"))) {
+			fluidIngredient = FluidIngredient.deserialize(map.toJson());
+		} else {
+			fluidIngredient = FluidIngredient.fromFluidStack(FluidStackHooksForge.toForge(FluidStackJS.of(fluidStack).getFluidStack()));
+		}
+
+		fluidHandlers.add(new OpenEndedPipe.IEffectHandler() {
+			@Override
+			public boolean canApplyEffects(OpenEndedPipe pipe, FluidStack fluid) {
+				return fluidIngredient.test(fluid);
+			}
+
+			@Override
+			public void applyEffects(OpenEndedPipe pipe, FluidStack fluid) {
+				handler.accept(pipe, FluidStackJS.of(fluid));
+			}
+		});
+	}
+}

--- a/src/main/java/dev/latvian/mods/kubejs/create/SpecialSpoutHandlerEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/create/SpecialSpoutHandlerEvent.java
@@ -3,6 +3,7 @@ package dev.latvian.mods.kubejs.create;
 import com.simibubi.create.api.behaviour.BlockSpoutingBehaviour;
 import com.simibubi.create.content.contraptions.fluids.actors.SpoutTileEntity;
 import com.simibubi.create.foundation.utility.Pair;
+import dev.architectury.hooks.fluid.forge.FluidStackHooksForge;
 import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
 import dev.latvian.mods.kubejs.event.EventJS;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
@@ -36,7 +37,7 @@ public class SpecialSpoutHandlerEvent extends EventJS {
 			public int fillBlock(Level world, BlockPos pos, SpoutTileEntity spout, FluidStack availableFluid, boolean simulate) {
 				if (!block.test(world.getBlockState(pos)))
 					return 0;
-				return handler.fillBlock(new BlockContainerJS(world, pos), FluidStackJS.of(availableFluid), simulate);
+				return handler.fillBlock(new BlockContainerJS(world, pos), FluidStackJS.of(FluidStackHooksForge.fromForge(availableFluid)), simulate);
 			}
 		}));
 	}

--- a/src/main/java/dev/latvian/mods/kubejs/create/SpecialSpoutHandlerEvent.java
+++ b/src/main/java/dev/latvian/mods/kubejs/create/SpecialSpoutHandlerEvent.java
@@ -1,0 +1,43 @@
+package dev.latvian.mods.kubejs.create;
+
+import com.simibubi.create.api.behaviour.BlockSpoutingBehaviour;
+import com.simibubi.create.content.contraptions.fluids.actors.SpoutTileEntity;
+import com.simibubi.create.foundation.utility.Pair;
+import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
+import dev.latvian.mods.kubejs.event.EventJS;
+import dev.latvian.mods.kubejs.fluid.FluidStackJS;
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.fluids.FluidStack;
+
+import java.util.List;
+
+/**
+ * @author Prunoideae
+ */
+public class SpecialSpoutHandlerEvent extends EventJS {
+	public static final String ID = "create.spout.special";
+	private final List<Pair<ResourceLocation, BlockSpoutingBehaviour>> behaviours;
+
+	@FunctionalInterface
+	public interface SpoutHandler {
+		int fillBlock(BlockContainerJS block, FluidStackJS fluid, boolean simulate);
+	}
+
+	public SpecialSpoutHandlerEvent(List<Pair<ResourceLocation, BlockSpoutingBehaviour>> behaviours) {
+		this.behaviours = behaviours;
+	}
+
+	public void addSpoutHandler(ResourceLocation path, BlockStatePredicate block, SpoutHandler handler) {
+		behaviours.add(Pair.of(path, new BlockSpoutingBehaviour() {
+			@Override
+			public int fillBlock(Level world, BlockPos pos, SpoutTileEntity spout, FluidStack availableFluid, boolean simulate) {
+				if (!block.test(world.getBlockState(pos)))
+					return 0;
+				return handler.fillBlock(new BlockContainerJS(world, pos), FluidStackJS.of(availableFluid), simulate);
+			}
+		}));
+	}
+}


### PR DESCRIPTION
Added support from KubeJS Create side of:
https://github.com/Creators-of-Create/Create/wiki/Custom-Spout-Interaction
https://github.com/Creators-of-Create/Create/wiki/Open-Ended-Pipe-Effect-Handlers

Example:
```js
//Works in startup_scripts

onEvent("create.pipe.fluid_effect", event => {
    //Creates a handler for the fluid, FluidIngredient is supported.
    event.addFluidHandler(Fluid.of("create:chocolate"), (pipe, stack) => {
        var world = pipe.world;
        if (world.gameTime % 5 != 0)
            return;
        var level = Utils.getLevel(world);
        level.getEntitiesWithin(pipe.getAOE()).forEach(entity => {
            if (entity.living) {
                entity.heal(5);
            }
        })
    })
})

onEvent("create.spout.special", event => {
    //Creates a handler for spout, the id is required as there's no way to generate a consistent uuid here.
    //
    //Spout will call the handler with simulate = true for every tick, if the returned value > 0, then
    //the spout will start its animation, handler will be called with simulate = false again at the end of
    //the animation. 
    //
    //The returned integer is how much fluid should this operation consume.
    event.addSpoutHandler("kubejs:obsidian", "minecraft:lava", (block, fluid, simulate) => {
        if (fluid.id == "minecraft:water" && fluid.amount >= 100) {
            if (!simulate)
                block.setBlockState(Block.getBlock("minecraft:obsidian").defaultBlockState(), 2);
            return 100;
        }
        return 0;
    })
})
```