### PR TITLE
v0.5 Update

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/create/ItemApplicationRecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/ItemApplicationRecipeJS.java
@@ -1,0 +1,13 @@
+package dev.latvian.mods.kubejs.create;
+
+public class ItemApplicationRecipeJS extends ProcessingRecipeJS {
+	public ItemApplicationRecipeJS keepHeldItem(boolean keep) {
+		json.addProperty("keepHeldItem", keep);
+		save();
+		return this;
+	}
+
+	public ItemApplicationRecipeJS keepHeldItem() {
+		return keepHeldItem(true);
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
@@ -1,19 +1,41 @@
 package dev.latvian.mods.kubejs.create;
 
+import com.google.common.collect.ImmutableMap;
 import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.content.contraptions.processing.ProcessingRecipeSerializer;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
 import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.create.events.BoilerHeaterHandlerEvent;
+import dev.latvian.mods.kubejs.create.events.SpecialFluidHandlerEvent;
+import dev.latvian.mods.kubejs.create.events.SpecialSpoutHandlerEvent;
+import dev.latvian.mods.kubejs.recipe.RecipeJS;
 import dev.latvian.mods.kubejs.recipe.RegisterRecipeHandlersEvent;
+import dev.latvian.mods.kubejs.script.ScriptType;
 import net.minecraft.resources.ResourceLocation;
+
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * @author LatvianModder
  */
 public class KubeJSCreatePlugin extends KubeJSPlugin {
+
+	private static final Map<ResourceLocation, Supplier<RecipeJS>> recipeProviders = ImmutableMap.<ResourceLocation, Supplier<RecipeJS>>builder()
+			.put(new ResourceLocation("create:deploying"), ItemApplicationRecipeJS::new)
+			.put(new ResourceLocation("create:item_application"), ItemApplicationRecipeJS::new)
+			.build();
+
 	@Override
 	public void init() {
 		RegistryObjectBuilderTypes.ITEM.addType("create:sequenced_assembly", SequencedAssemblyItemBuilder.class, SequencedAssemblyItemBuilder::new);
+	}
+
+	@Override
+	public void afterInit() {
+		new SpecialSpoutHandlerEvent().post(ScriptType.STARTUP, SpecialSpoutHandlerEvent.ID);
+		new SpecialFluidHandlerEvent().post(ScriptType.STARTUP, SpecialFluidHandlerEvent.ID);
+		new BoilerHeaterHandlerEvent().post(ScriptType.STARTUP, BoilerHeaterHandlerEvent.ID);
 	}
 
 	@Override
@@ -23,7 +45,7 @@ public class KubeJSCreatePlugin extends KubeJSPlugin {
 
 		for (var createRecipeType : AllRecipeTypes.values()) {
 			if (createRecipeType.getSerializer() instanceof ProcessingRecipeSerializer) {
-				event.register(createRecipeType.getId(), ProcessingRecipeJS::new);
+				event.register(createRecipeType.getId(), recipeProviders.getOrDefault(createRecipeType.getId(), ProcessingRecipeJS::new));
 			}
 		}
 	}

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
@@ -1,6 +1,5 @@
 package dev.latvian.mods.kubejs.create;
 
-import com.google.common.collect.ImmutableMap;
 import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.content.contraptions.processing.ProcessingRecipeSerializer;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
@@ -21,10 +20,10 @@ import java.util.function.Supplier;
  */
 public class KubeJSCreatePlugin extends KubeJSPlugin {
 
-	private static final Map<ResourceLocation, Supplier<RecipeJS>> recipeProviders = ImmutableMap.<ResourceLocation, Supplier<RecipeJS>>builder()
-			.put(new ResourceLocation("create:deploying"), ItemApplicationRecipeJS::new)
-			.put(new ResourceLocation("create:item_application"), ItemApplicationRecipeJS::new)
-			.build();
+	private static final Map<ResourceLocation, Supplier<RecipeJS>> recipeProviders = Map.of(
+			new ResourceLocation("create:deploying"), ItemApplicationRecipeJS::new,
+			new ResourceLocation("create:item_application"), ItemApplicationRecipeJS::new
+	);
 
 	@Override
 	public void init() {

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/events/BoilerHeaterHandlerEvent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/events/BoilerHeaterHandlerEvent.java
@@ -1,0 +1,26 @@
+package dev.latvian.mods.kubejs.create.events;
+
+import com.simibubi.create.content.contraptions.fluids.tank.BoilerHeaters;
+import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
+import dev.latvian.mods.kubejs.create.platform.BoilerHeaterHelper;
+import dev.latvian.mods.kubejs.event.EventJS;
+import dev.latvian.mods.kubejs.level.BlockContainerJS;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.world.level.block.Block;
+
+public class BoilerHeaterHandlerEvent extends EventJS {
+	public static final String ID = "create.boiler.heater";
+
+	@FunctionalInterface
+	public interface BoilerHeaterCallback {
+		float updateHeat(BlockContainerJS block);
+	}
+
+	public void registerHeater(Block block, BoilerHeaterCallback onUpdate) {
+		BoilerHeaterHelper.registerHeaterPlatform(block, onUpdate);
+	}
+
+	public void registerHeaterAdvanced(BlockStatePredicate block, BoilerHeaterCallback onUpdate) {
+		BoilerHeaters.registerHeaterProvider(((level, blockPos, blockState) -> block.test(blockState) ? (l, b, bs) -> onUpdate.updateHeat(UtilsJS.getLevel(l).getBlock(b)) : null));
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/events/SpecialFluidHandlerEvent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/events/SpecialFluidHandlerEvent.java
@@ -1,4 +1,4 @@
-package dev.latvian.mods.kubejs.create;
+package dev.latvian.mods.kubejs.create.events;
 
 import com.simibubi.create.content.contraptions.fluids.OpenEndedPipe;
 import com.simibubi.create.foundation.fluid.FluidIngredient;
@@ -7,7 +7,6 @@ import dev.latvian.mods.kubejs.event.EventJS;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 import dev.latvian.mods.kubejs.util.MapJS;
 
-import java.util.List;
 import java.util.function.BiConsumer;
 
 /**
@@ -15,12 +14,6 @@ import java.util.function.BiConsumer;
  */
 public class SpecialFluidHandlerEvent extends EventJS {
 	public static final String ID = "create.pipe.fluid_effect";
-
-	private final List<OpenEndedPipe.IEffectHandler> fluidHandlers;
-
-	public SpecialFluidHandlerEvent(List<OpenEndedPipe.IEffectHandler> fluidHandlers) {
-		this.fluidHandlers = fluidHandlers;
-	}
 
 	public void addFluidHandler(Object fluidStack, BiConsumer<OpenEndedPipe, FluidStackJS> handler) {
 		FluidIngredient fluidIngredient;
@@ -32,6 +25,6 @@ public class SpecialFluidHandlerEvent extends EventJS {
 			fluidIngredient = FluidIngredientHelper.toFluidIngredient(FluidStackJS.of(fluidStack));
 		}
 
-		fluidHandlers.add(FluidIngredientHelper.createEffectHandler(fluidIngredient, handler));
+		OpenEndedPipe.registerEffectHandler(FluidIngredientHelper.createEffectHandler(fluidIngredient, handler));
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/events/SpecialSpoutHandlerEvent.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/events/SpecialSpoutHandlerEvent.java
@@ -1,4 +1,4 @@
-package dev.latvian.mods.kubejs.create;
+package dev.latvian.mods.kubejs.create.events;
 
 import com.simibubi.create.api.behaviour.BlockSpoutingBehaviour;
 import com.simibubi.create.foundation.utility.Pair;
@@ -16,18 +16,13 @@ import java.util.List;
  */
 public class SpecialSpoutHandlerEvent extends EventJS {
 	public static final String ID = "create.spout.special";
-	private final List<Pair<ResourceLocation, BlockSpoutingBehaviour>> behaviours;
 
 	@FunctionalInterface
 	public interface SpoutHandler {
 		long fillBlock(BlockContainerJS block, FluidStackJS fluid, boolean simulate);
 	}
 
-	public SpecialSpoutHandlerEvent(List<Pair<ResourceLocation, BlockSpoutingBehaviour>> behaviours) {
-		this.behaviours = behaviours;
-	}
-
 	public void addSpoutHandler(ResourceLocation path, BlockStatePredicate block, SpoutHandler handler) {
-		behaviours.add(Pair.of(path, FluidIngredientHelper.createSpoutingHandler(block, handler)));
+		BlockSpoutingBehaviour.addCustomSpoutInteraction(path, FluidIngredientHelper.createSpoutingHandler(block, handler));
 	}
 }

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/platform/BoilerHeaterHelper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/platform/BoilerHeaterHelper.java
@@ -1,0 +1,12 @@
+package dev.latvian.mods.kubejs.create.platform;
+
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import dev.latvian.mods.kubejs.create.events.BoilerHeaterHandlerEvent;
+import net.minecraft.world.level.block.Block;
+
+public class BoilerHeaterHelper {
+	@ExpectPlatform
+	public static void registerHeaterPlatform(Block block, BoilerHeaterHandlerEvent.BoilerHeaterCallback onUpdate) {
+		throw new AssertionError("Not implemented");
+	}
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/platform/FluidIngredientHelper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/platform/FluidIngredientHelper.java
@@ -9,7 +9,7 @@ import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 
 import java.util.function.BiConsumer;
 
-import static dev.latvian.mods.kubejs.create.SpecialSpoutHandlerEvent.SpoutHandler;
+import static dev.latvian.mods.kubejs.create.events.SpecialSpoutHandlerEvent.SpoutHandler;
 
 public class FluidIngredientHelper {
 
@@ -19,7 +19,6 @@ public class FluidIngredientHelper {
 	}
 
 	@ExpectPlatform
-
 	public static OpenEndedPipe.IEffectHandler createEffectHandler(FluidIngredient fluidIngredient, BiConsumer<OpenEndedPipe, FluidStackJS> handler) {
 		throw new AssertionError("Not implemented");
 	}

--- a/fabric/src/main/java/dev/latvian/mods/kubejs/create/platform/fabric/BoilerHeaterHelperImpl.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/create/platform/fabric/BoilerHeaterHelperImpl.java
@@ -1,0 +1,12 @@
+package dev.latvian.mods.kubejs.create.platform.fabric;
+
+import com.simibubi.create.content.contraptions.fluids.tank.BoilerHeaters;
+import dev.latvian.mods.kubejs.create.events.BoilerHeaterHandlerEvent;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.world.level.block.Block;
+
+public class BoilerHeaterHelperImpl {
+    public static void registerHeaterPlatform(Block block, BoilerHeaterHandlerEvent.BoilerHeaterCallback onUpdate) {
+        BoilerHeaters.registerHeater(block, (level, blockPos, blockState) -> onUpdate.updateHeat(UtilsJS.getLevel(level).getBlock(blockPos)));
+    }
+}

--- a/fabric/src/main/java/dev/latvian/mods/kubejs/create/platform/fabric/FluidIngredientHelperImpl.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/create/platform/fabric/FluidIngredientHelperImpl.java
@@ -5,7 +5,7 @@ import com.simibubi.create.content.contraptions.fluids.OpenEndedPipe;
 import com.simibubi.create.content.contraptions.fluids.actors.SpoutTileEntity;
 import com.simibubi.create.foundation.fluid.FluidIngredient;
 import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
-import dev.latvian.mods.kubejs.create.SpecialSpoutHandlerEvent;
+import dev.latvian.mods.kubejs.create.events.SpecialSpoutHandlerEvent;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import io.github.fabricators_of_create.porting_lib.util.FluidStack;

--- a/forge/src/main/java/dev/latvian/mods/kubejs/create/platform/forge/BoilerHeaterHelperImpl.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/create/platform/forge/BoilerHeaterHelperImpl.java
@@ -1,0 +1,12 @@
+package dev.latvian.mods.kubejs.create.platform.forge;
+
+import com.simibubi.create.content.contraptions.fluids.tank.BoilerHeaters;
+import dev.latvian.mods.kubejs.create.events.BoilerHeaterHandlerEvent;
+import dev.latvian.mods.kubejs.util.UtilsJS;
+import net.minecraft.world.level.block.Block;
+
+public class BoilerHeaterHelperImpl {
+	public static void registerHeaterPlatform(Block block, BoilerHeaterHandlerEvent.BoilerHeaterCallback onUpdate) {
+		BoilerHeaters.registerHeater(block.delegate, (level, blockPos, blockState) -> onUpdate.updateHeat(UtilsJS.getLevel(level).getBlock(blockPos)));
+	}
+}

--- a/forge/src/main/java/dev/latvian/mods/kubejs/create/platform/forge/FluidIngredientHelperImpl.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/create/platform/forge/FluidIngredientHelperImpl.java
@@ -6,7 +6,7 @@ import com.simibubi.create.content.contraptions.fluids.actors.SpoutTileEntity;
 import com.simibubi.create.foundation.fluid.FluidIngredient;
 import dev.architectury.hooks.fluid.forge.FluidStackHooksForge;
 import dev.latvian.mods.kubejs.block.state.BlockStatePredicate;
-import dev.latvian.mods.kubejs.create.SpecialSpoutHandlerEvent;
+import dev.latvian.mods.kubejs.create.events.SpecialSpoutHandlerEvent;
 import dev.latvian.mods.kubejs.fluid.FluidStackJS;
 import dev.latvian.mods.kubejs.level.BlockContainerJS;
 import net.minecraft.core.BlockPos;

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ minecraft_version=1.18.2
 curseforge_id=429371
 curseforge_type=beta
 
-create_version=mc1.18.2_v0.4.1+
+create_version=mc1.18.2_v0.5.0+
 flywheel_forge_version=1.18-0.7.0.67
 rei_version=8.2.463
 


### PR DESCRIPTION
- Cleaned up some of the code and refactored project structure to make it clearer.
- Added `.keepHeldItem()` for Item Application and Deployer recipes.
- Re-added spout handlers and fluid handlers event not fired for some weird reasons,
- Added support for adding special heat sources to Boiler in v0.5.

```js
onEvent("create.boiler.heater", event => {
    /**
     * Explanation of Heat Level:
     * -1: This block does not provide heat in any form.
     * 0 : This block provides passive heat. (Like unfueled blaze burners)
     * 1 : This block provides 1 unit of heat (1 green bar in the status, like fueled blaze burners)
     * 2 : This block provides 2 units of heat (like blaze-caked burners)
     * X : This block provides X units of heat, which is X green bars in the status
     */

    /**
     * Register a heater for a single block.
     * The parameter in the callback is a BlockContainerJS.
     */
    event.registerHeater("diamond_block", block => {
        return 2
    })

    /**
     * Register a heater for a block predicate.
     */
    event.registerHeaterAdvanced("#minecraft:logs", block => {
        return block.id == "minecraft:oak_log" ? 1 : 2
    })
})
```
![unknown](https://user-images.githubusercontent.com/24620047/183256385-207dd1b0-2a6a-4ae9-8672-648927fb650e.png)

