### PR TITLE
Add custom cogs using kubejs scripts

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
@@ -4,6 +4,7 @@ import com.simibubi.create.AllRecipeTypes;
 import com.simibubi.create.content.contraptions.processing.ProcessingRecipeSerializer;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
 import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.create.cogwheel.CogWheelBlockBuilder;
 import dev.latvian.mods.kubejs.create.events.BoilerHeaterHandlerEvent;
 import dev.latvian.mods.kubejs.create.events.SpecialFluidHandlerEvent;
 import dev.latvian.mods.kubejs.create.events.SpecialSpoutHandlerEvent;
@@ -28,6 +29,7 @@ public class KubeJSCreatePlugin extends KubeJSPlugin {
 	@Override
 	public void init() {
 		RegistryObjectBuilderTypes.ITEM.addType("create:sequenced_assembly", SequencedAssemblyItemBuilder.class, SequencedAssemblyItemBuilder::new);
+		RegistryObjectBuilderTypes.BLOCK.addType("create:cog_wheel", CogWheelBlockBuilder.class, CogWheelBlockBuilder::new);
 	}
 
 	@Override

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/cogwheel/CogWheelBlockBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/cogwheel/CogWheelBlockBuilder.java
@@ -1,0 +1,38 @@
+package dev.latvian.mods.kubejs.create.cogwheel;
+
+import com.simibubi.create.content.contraptions.relays.elementary.CogWheelBlock;
+import dev.latvian.mods.kubejs.block.BlockBuilder;
+import dev.latvian.mods.kubejs.create.platform.CogWheelHelper;
+import net.minecraft.client.Minecraft;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.block.Block;
+
+public class CogWheelBlockBuilder extends BlockBuilder {
+
+    private boolean isLarge = false;
+
+    public CogWheelBlockBuilder(ResourceLocation i) {
+        super(i);
+        itemBuilder = new CogWheelItemBuilder(i);
+        itemBuilder.blockBuilder = this;
+    }
+
+    public void small() {
+        isLarge = false;
+    }
+
+    public void large() {
+        isLarge = true;
+    }
+
+    @Override
+    public Block createObject() {
+        return new CustomCogwheelBlock(isLarge, createProperties());
+    }
+
+    @Override
+    public void clientRegistry(Minecraft minecraft) {
+        super.clientRegistry(minecraft);
+        CogWheelHelper.registerModel(asRegistrySupplier().get());
+    }
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/cogwheel/CogWheelItemBuilder.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/cogwheel/CogWheelItemBuilder.java
@@ -1,0 +1,27 @@
+package dev.latvian.mods.kubejs.create.cogwheel;
+
+import com.simibubi.create.content.contraptions.relays.elementary.CogWheelBlock;
+import com.simibubi.create.content.contraptions.relays.elementary.CogwheelBlockItem;
+import dev.latvian.mods.kubejs.block.BlockBuilder;
+import dev.latvian.mods.kubejs.block.BlockItemBuilder;
+import dev.latvian.mods.kubejs.item.ItemBuilder;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+
+public class CogWheelItemBuilder extends BlockItemBuilder {
+
+    public CogWheelItemBuilder(ResourceLocation i) {
+        super(i);
+    }
+
+    @Override
+    public Item createObject() {
+        var block = blockBuilder.get();
+        if (block instanceof CogWheelBlock cog) {
+            return new CogwheelBlockItem(cog, createItemProperties());
+        } else {
+            return null;
+        }
+    }
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/cogwheel/CustomCogwheelBlock.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/cogwheel/CustomCogwheelBlock.java
@@ -1,0 +1,30 @@
+package dev.latvian.mods.kubejs.create.cogwheel;
+
+import com.simibubi.create.content.contraptions.base.KineticTileEntity;
+import com.simibubi.create.content.contraptions.relays.elementary.CogWheelBlock;
+import dev.latvian.mods.kubejs.create.platform.CogWheelHelper;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+public class CustomCogwheelBlock extends CogWheelBlock {
+
+    public CustomCogwheelBlock(boolean large, Properties properties) {
+        super(large, properties);
+    }
+
+    @Override
+    public BlockEntityType<? extends KineticTileEntity> getTileEntityType() {
+        return CogWheelHelper.getCogWheel();
+    }
+
+    @Override
+    public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult ray) {
+        return InteractionResult.PASS;
+    }
+}

--- a/common/src/main/java/dev/latvian/mods/kubejs/create/platform/CogWheelHelper.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/platform/CogWheelHelper.java
@@ -1,0 +1,22 @@
+package dev.latvian.mods.kubejs.create.platform;
+
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticTileEntity;
+import com.simibubi.create.foundation.data.CreateRegistrate;
+import dev.architectury.injectables.annotations.ExpectPlatform;
+import dev.latvian.mods.kubejs.create.events.BoilerHeaterHandlerEvent;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+public class CogWheelHelper {
+
+	@ExpectPlatform
+	public static void registerModel(Block block) {
+		throw new AssertionError("Not implemented");
+	}
+
+	@ExpectPlatform
+	public static BlockEntityType<BracketedKineticTileEntity> getCogWheel() {
+		throw new AssertionError("Not implemented");
+	}
+
+}

--- a/fabric/src/main/java/dev/latvian/mods/kubejs/create/fabric/CustomCogInstance.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/create/fabric/CustomCogInstance.java
@@ -1,0 +1,19 @@
+package dev.latvian.mods.kubejs.create.fabric;
+
+import com.jozufozu.flywheel.api.Instancer;
+import com.jozufozu.flywheel.api.MaterialManager;
+import com.simibubi.create.content.contraptions.base.KineticTileEntity;
+import com.simibubi.create.content.contraptions.base.flwdata.RotatingData;
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticTileInstance;
+
+public class CustomCogInstance extends BracketedKineticTileInstance {
+
+    public CustomCogInstance(MaterialManager modelManager, KineticTileEntity tile) {
+        super(modelManager, tile);
+    }
+
+    @Override
+    protected Instancer<RotatingData> getModel() {
+        return getRotatingMaterial().getModel(getRenderedBlockState());
+    }
+}

--- a/fabric/src/main/java/dev/latvian/mods/kubejs/create/fabric/KubeJSCreateFabric.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/create/fabric/KubeJSCreateFabric.java
@@ -1,0 +1,19 @@
+package dev.latvian.mods.kubejs.create.fabric;
+
+import com.simibubi.create.foundation.data.CreateRegistrate;
+import com.tterrag.registrate.util.nullness.NonNullSupplier;
+import dev.latvian.mods.kubejs.create.KubeJSCreate;
+import dev.latvian.mods.kubejs.create.platform.fabric.CogWheelHelperImpl;
+import net.fabricmc.api.ModInitializer;
+
+public class KubeJSCreateFabric implements ModInitializer {
+
+    public static final NonNullSupplier<CreateRegistrate> REGISTRATE = CreateRegistrate.lazy("kubejs");
+
+    @Override
+    public void onInitialize() {
+        KubeJSCreate.init();
+        CogWheelHelperImpl.register();
+    }
+
+}

--- a/fabric/src/main/java/dev/latvian/mods/kubejs/create/platform/fabric/CogWheelHelperImpl.java
+++ b/fabric/src/main/java/dev/latvian/mods/kubejs/create/platform/fabric/CogWheelHelperImpl.java
@@ -1,0 +1,42 @@
+package dev.latvian.mods.kubejs.create.platform.fabric;
+
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticBlockModel;
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticTileEntity;
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticTileRenderer;
+import com.simibubi.create.foundation.data.CreateRegistrate;
+import com.tterrag.registrate.util.entry.BlockEntityEntry;
+import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.create.cogwheel.CustomCogwheelBlock;
+import dev.latvian.mods.kubejs.create.fabric.CustomCogInstance;
+import dev.latvian.mods.kubejs.create.fabric.KubeJSCreateFabric;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+import java.util.Map;
+
+public class CogWheelHelperImpl {
+
+    private static BlockEntityEntry<BracketedKineticTileEntity> customCogwheel;
+
+    public static void registerModel(Block block) {
+        CreateRegistrate.blockModel(() -> BracketedKineticBlockModel::new).accept(block);
+    }
+
+    public static BlockEntityType<BracketedKineticTileEntity> getCogWheel() {
+        return customCogwheel.get();
+    }
+
+    public static void register() {
+        var customBlocks = RegistryObjectBuilderTypes.BLOCK.deferredRegister.getRegistrar().entrySet();
+        var customCogs = customBlocks.stream().map(Map.Entry::getValue).filter(CustomCogwheelBlock.class::isInstance);
+
+        var builder = KubeJSCreateFabric.REGISTRATE.get()
+                .tileEntity("cogwheel", BracketedKineticTileEntity::new)
+                .instance(() -> CustomCogInstance::new, false)
+                .renderer(() -> BracketedKineticTileRenderer::new);
+
+        customCogs.forEach(it -> builder.validBlock(() -> it));
+        customCogwheel = builder.register();
+    }
+
+}

--- a/forge/src/main/java/dev/latvian/mods/kubejs/create/forge/CustomCogInstance.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/create/forge/CustomCogInstance.java
@@ -1,0 +1,19 @@
+package dev.latvian.mods.kubejs.create.forge;
+
+import com.jozufozu.flywheel.api.Instancer;
+import com.jozufozu.flywheel.api.MaterialManager;
+import com.simibubi.create.content.contraptions.base.KineticTileEntity;
+import com.simibubi.create.content.contraptions.base.flwdata.RotatingData;
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticTileInstance;
+
+public class CustomCogInstance extends BracketedKineticTileInstance {
+
+    public CustomCogInstance(MaterialManager modelManager, KineticTileEntity tile) {
+        super(modelManager, tile);
+    }
+
+    @Override
+    protected Instancer<RotatingData> getModel() {
+        return getRotatingMaterial().getModel(getRenderedBlockState());
+    }
+}

--- a/forge/src/main/java/dev/latvian/mods/kubejs/create/forge/KubeJSCreateForge.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/create/forge/KubeJSCreateForge.java
@@ -1,11 +1,20 @@
 package dev.latvian.mods.kubejs.create.forge;
 
+import com.simibubi.create.foundation.data.CreateRegistrate;
+import com.simibubi.create.repack.registrate.util.nullness.NonNullSupplier;
 import dev.latvian.mods.kubejs.create.KubeJSCreate;
+import dev.latvian.mods.kubejs.create.platform.CogWheelHelper;
+import dev.latvian.mods.kubejs.create.platform.forge.CogWheelHelperImpl;
 import net.minecraftforge.fml.common.Mod;
 
 @Mod("kubejs_create")
 public class KubeJSCreateForge {
+
+	public static final NonNullSupplier<CreateRegistrate> REGISTRATE = CreateRegistrate.lazy("kubejs");
+
 	public KubeJSCreateForge() {
 		KubeJSCreate.init();
+		CogWheelHelperImpl.init();
 	}
+
 }

--- a/forge/src/main/java/dev/latvian/mods/kubejs/create/platform/forge/CogWheelHelperImpl.java
+++ b/forge/src/main/java/dev/latvian/mods/kubejs/create/platform/forge/CogWheelHelperImpl.java
@@ -1,0 +1,49 @@
+package dev.latvian.mods.kubejs.create.platform.forge;
+
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticBlockModel;
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticTileEntity;
+import com.simibubi.create.content.contraptions.relays.elementary.BracketedKineticTileRenderer;
+import com.simibubi.create.foundation.data.CreateRegistrate;
+import com.simibubi.create.repack.registrate.util.entry.BlockEntityEntry;
+import dev.latvian.mods.kubejs.RegistryObjectBuilderTypes;
+import dev.latvian.mods.kubejs.create.cogwheel.CustomCogwheelBlock;
+import dev.latvian.mods.kubejs.create.forge.CustomCogInstance;
+import dev.latvian.mods.kubejs.create.forge.KubeJSCreateForge;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.event.RegistryEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+
+import java.util.Map;
+
+public class CogWheelHelperImpl {
+
+    private static BlockEntityEntry<BracketedKineticTileEntity> customCogwheel;
+
+    public static void registerModel(Block block) {
+        CreateRegistrate.blockModel(() -> BracketedKineticBlockModel::new).accept(block);
+    }
+
+    public static BlockEntityType<BracketedKineticTileEntity> getCogWheel() {
+        return customCogwheel.get();
+    }
+
+    private static void register(RegistryEvent.Register<Block> event) {
+        var customBlocks = RegistryObjectBuilderTypes.BLOCK.deferredRegister.getRegistrar().entrySet();
+        var customCogs = customBlocks.stream().map(Map.Entry::getValue).filter(CustomCogwheelBlock.class::isInstance);
+
+        var builder = KubeJSCreateForge.REGISTRATE.get()
+                .tileEntity("cogwheel", BracketedKineticTileEntity::new)
+                .instance(() -> CustomCogInstance::new, false)
+                .renderer(() -> BracketedKineticTileRenderer::new);
+
+        customCogs.forEach(it -> builder.validBlock(() -> it));
+        customCogwheel = builder.register();
+    }
+
+    public static void init() {
+        FMLJavaModLoadingContext.get().getModEventBus().addGenericListener(Block.class, EventPriority.HIGH, CogWheelHelperImpl::register);
+    }
+
+}


### PR DESCRIPTION
### Disclaimer 
Not sure if this is something you want to be part of the mod, but I felt like instead of creating a seperate mod for this, it makes sense to be part of this addon.

### Feature
- Added a KubeJS BlockBuilder for CogWheels
- Allows creation of small & large cogwheels using kubejs scripts

### Problems
- Most of the code is duplicated, because I cannot reference a lot of classes in the common module (for example registrate)
- Cogs are not able to be encased (for now), since that would also require the registration of the encased blocks