### PR TITLE
Fixed recipes don't respect ingredient count

### DIFF
--- a/common/src/main/java/dev/latvian/mods/kubejs/create/ProcessingRecipeJS.java
+++ b/common/src/main/java/dev/latvian/mods/kubejs/create/ProcessingRecipeJS.java
@@ -97,7 +97,7 @@ public class ProcessingRecipeJS extends RecipeJS {
 			var jsonIngredients = new JsonArray();
 
 			for (var inputStack : inputItems) {
-				jsonIngredients.add(inputStack.toJson());
+				inputStack.kjs$unwrapStackIngredient().forEach(ingredient -> jsonIngredients.add(ingredient.toJson()));
 			}
 
 			for (var fluid : inputFluids) {


### PR DESCRIPTION
Fixed the problem of KJS Create doesn't recognize IngredientStack, allowing writing:
```js
ServerEvents.recipes(event => {
    let { create } = event.recipes

    create.compacting("immersiveengineering:drillhead_steel", [Ingredient.of("blaze_rod", 32), "immersiveengineering:drillhead_iron"])
        .superheated()
})
```
Instead of
```js
ServerEvents.recipes(event => {
    let { create } = event.recipes

    create.compacting("immersiveengineering:drillhead_steel", ["blaze_rod"... (repeat 32 times), "immersiveengineering:drillhead_iron"])
        .superheated()
})
```

