### PR TITLE
1902/forge

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/create/KubeJSCreatePlugin.java
@@ -30,7 +30,10 @@ public class KubeJSCreatePlugin extends KubeJSPlugin {
 			AllRecipeTypes.DEPLOYING, ProcessingRecipeSchema.ITEM_APPLICATION,
 			AllRecipeTypes.ITEM_APPLICATION, ProcessingRecipeSchema.ITEM_APPLICATION,
 			AllRecipeTypes.MIXING, ProcessingRecipeSchema.PROCESSING_UNWRAPPED,
-			AllRecipeTypes.COMPACTING, ProcessingRecipeSchema.PROCESSING_UNWRAPPED
+			AllRecipeTypes.COMPACTING, ProcessingRecipeSchema.PROCESSING_UNWRAPPED,
+			AllRecipeTypes.CRUSHING, ProcessingRecipeSchema.PROCESSING_WITH_TIME,
+			AllRecipeTypes.CUTTING, ProcessingRecipeSchema.PROCESSING_WITH_TIME,
+			AllRecipeTypes.MILLING, ProcessingRecipeSchema.PROCESSING_WITH_TIME
 	);
 
 	@Override

--- a/src/main/java/dev/latvian/mods/kubejs/create/ProcessingRecipeSchema.java
+++ b/src/main/java/dev/latvian/mods/kubejs/create/ProcessingRecipeSchema.java
@@ -54,7 +54,7 @@ public interface ProcessingRecipeSchema {
 		}
 	}.key("ingredients");
 
-	RecipeKey<Long> PROCESSING_TIME = TimeComponent.TICKS.key("processingTime").optional(100L);
+	RecipeKey<Long> PROCESSING_TIME = TimeComponent.TICKS.key("processingTime").optional(100L).alwaysWrite();
 
 	RecipeKey<String> HEAT_REQUIREMENT = new StringComponent("not a valid heat condition!", s -> {
 		for (var h : HeatCondition.values()) {

--- a/src/main/java/dev/latvian/mods/kubejs/create/ProcessingRecipeSchema.java
+++ b/src/main/java/dev/latvian/mods/kubejs/create/ProcessingRecipeSchema.java
@@ -54,7 +54,11 @@ public interface ProcessingRecipeSchema {
 		}
 	}.key("ingredients");
 
-	RecipeKey<Long> PROCESSING_TIME = TimeComponent.TICKS.key("processingTime").optional(100L).alwaysWrite();
+	RecipeKey<Long> PROCESSING_TIME = TimeComponent.TICKS.key("processingTime").optional(100L);
+	// specifically for crushing, cutting and milling
+	RecipeKey<Long> PROCESSING_TIME_REQUIRED = TimeComponent.TICKS.key("processingTime").optional(100L).alwaysWrite();
+
+
 
 	RecipeKey<String> HEAT_REQUIREMENT = new StringComponent("not a valid heat condition!", s -> {
 		for (var h : HeatCondition.values()) {
@@ -149,6 +153,8 @@ public interface ProcessingRecipeSchema {
 	}
 
 	RecipeSchema PROCESSING_DEFAULT = new RecipeSchema(ProcessingRecipeJS.class, ProcessingRecipeJS::new, RESULTS, INGREDIENTS, PROCESSING_TIME, HEAT_REQUIREMENT);
+
+	RecipeSchema PROCESSING_WITH_TIME = new RecipeSchema(ProcessingRecipeJS.class, ProcessingRecipeJS::new, RESULTS, INGREDIENTS, PROCESSING_TIME_REQUIRED, HEAT_REQUIREMENT);
 
 	RecipeSchema PROCESSING_UNWRAPPED = new RecipeSchema(ProcessingRecipeJS.class, ProcessingRecipeJS::new, RESULTS, INGREDIENTS_UNWRAPPED, PROCESSING_TIME, HEAT_REQUIREMENT);
 


### PR DESCRIPTION
Crushing, cutting and milling recipes need `processingTime` to work properly. 

I like how recipes are created in kjs... with processingTime optional.

May be there is a better way to do it but `alwaysWrite()` fixes the problem and mantains consistency through all recipes.

The rest of the ProcessingRecipes ignore the parameter so the same result can be achieved without creating a different schema.

Fixes #32 